### PR TITLE
Use brews openssl if available

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,10 @@ export PATH="$PATH:~/bin/"
 # the PATH will need to be set in your shell config
 ```
 
+### OSX
+
+The built in openssl of osx is broken, showing a useless `Usage: rsautl [options]` message. If you add it via brew `brew install openssl@1.1` catacomb will use that one.
+
 ## Usage
 
 ### Encrypting

--- a/bin/catacomb
+++ b/bin/catacomb
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# default osx openssl is broken, use the brew one if available
+if [ "$(uname)" == "Darwin" ] && BREW_PREFIX=$(brew --prefix openssl 2>/dev/null); then
+  PATH="$BREW_PREFIX/bin:$PATH"
+fi
+
 main() {
   if [[ -n "$1" ]]; then
     PUBLIC_KEY="$HOME/.ssh/$1.pub"


### PR DESCRIPTION
The built in openssl of osx is broken, showing a useless `Usage: rsautl [options]` message.